### PR TITLE
Add wakelock option for flashlight

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -297,5 +297,8 @@
     <!-- Duration of the expansion animation in the volume dialog -->
     <item name="volume_expand_animation_duration" type="integer">300</item>
 
+    <!-- Allow Flashlight service to use wakelock -->
+    <bool name="flashlight_use_wakelock">false</bool>
+
 </resources>
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/FlashlightController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/FlashlightController.java
@@ -29,6 +29,8 @@ import android.hardware.camera2.CameraManager;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Process;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -49,6 +51,8 @@ public class FlashlightController {
     private static final int DISPATCH_CHANGED = 1;
     private static final int DISPATCH_AVAILABILITY_CHANGED = 2;
 
+    private static boolean mUseWakeLock;
+
     private static final String ACTION_TURN_FLASHLIGHT_OFF =
             "com.android.systemui.action.TURN_FLASHLIGHT_OFF";
 
@@ -65,6 +69,8 @@ public class FlashlightController {
 
     private final String mCameraId;
     private boolean mTorchAvailable;
+
+    private WakeLock mWakeLock;
 
     private Notification mNotification = null;
     private boolean mReceiverRegistered;
@@ -98,6 +104,11 @@ public class FlashlightController {
             mCameraId = cameraId;
         }
 
+        mUseWakeLock = mContext.getResources().getBoolean(R.bool.flashlight_use_wakelock);
+
+        PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+        mWakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
+
         if (mCameraId != null) {
             ensureHandler();
             mCameraManager.registerTorchCallback(mTorchCallback, mHandler);
@@ -109,12 +120,25 @@ public class FlashlightController {
         synchronized (this) {
             if (mFlashlightEnabled != enabled) {
                 mFlashlightEnabled = enabled;
+
+                if (mUseWakeLock) {
+                    if (enabled) {
+                        if (!mWakeLock.isHeld()) mWakeLock.acquire();
+                    } else {
+                        if (mWakeLock.isHeld()) mWakeLock.release();
+                    }
+                }
+
                 try {
                     mCameraManager.setTorchMode(mCameraId, enabled);
                 } catch (CameraAccessException e) {
                     Log.e(TAG, "Couldn't set torch mode", e);
                     mFlashlightEnabled = false;
                     pendingError = true;
+
+                    if (mUseWakeLock && mWakeLock.isHeld()) {
+                        mWakeLock.release();
+                    }
                 }
             }
         }
@@ -287,6 +311,11 @@ public class FlashlightController {
             synchronized (FlashlightController.this) {
                 changed = mTorchAvailable != available;
                 mTorchAvailable = available;
+
+                if (mUseWakeLock && !available) {
+                    if (mWakeLock.isHeld())
+                        mWakeLock.release();
+                }
             }
             if (changed) {
                 if (DEBUG) Log.d(TAG, "dispatchAvailabilityChanged(" + available + ")");
@@ -299,6 +328,11 @@ public class FlashlightController {
             synchronized (FlashlightController.this) {
                 changed = mFlashlightEnabled != enabled;
                 mFlashlightEnabled = enabled;
+
+                if (mUseWakeLock && !enabled) {
+                    if (mWakeLock.isHeld())
+                        mWakeLock.release();
+                }
             }
             if (changed) {
                 if (DEBUG) Log.d(TAG, "dispatchModeChanged(" + enabled + ")");


### PR DESCRIPTION
On some legacy devices flashlight can't stay on when screen is off.
With this change, flashlight can use wakelock. For obvious reasons,
 this is turned off by default and needs to be enabled through overlay.

Change-Id: Ia69309cf023430c9e90634a722be97ebbf6677ca